### PR TITLE
Fixed onButtonReady is not fired when paypal sdk already present

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,9 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
         if (window !== undefined && window.paypal === undefined) {
             this.addPaypalSdk();
         }
+        else if (window !== undefined && window.paypal !== undefined) {
+            this.props.onButtonReady();
+        }
     }
 
     createOrder(data: any, actions: any) {


### PR DESCRIPTION
Unfortunately I found another bug that onButtonReady is not fired when the paypal sdk is already present and the component is mounted a second time.