### PR TITLE
Makes PayPalButton safe for SSR

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,7 +155,7 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
         } = this.props;
         const { isSdkReady } = this.state;
 
-        if (!isSdkReady && window.paypal === undefined) {
+        if (!isSdkReady || window.paypal === undefined) {
             return null;
         }
 


### PR DESCRIPTION
If the component renders on the server, the old code evals `!isSdkReady`, finds it to be `true` and then because of the `&&` it also has to check if `window.paypal` is true. That fails because `window` is undefined on the server. Switching to an `||` means that as soon as `!isSdkReady` evaluates to true, it doesn't need to evaluation the rest of the statement and `null` is returned.