### PR TITLE
Remove rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
         "path": "^0.12.7",
         "react": "^16.8.2",
         "react-dom": "^16.8.2",
-        "rimraf": "^3.0.0",
         "source-map-loader": "^0.2.4",
         "style-loader": "^0.23.1",
         "typescript": "^3.3.3",
@@ -98,7 +97,7 @@
         "webpack-dev-server": "^3.1.14"
     },
     "scripts": {
-        "build": "rimraf dist lib && npm run build:types && npm run build:js",
+        "build": "rm -rf dist lib && npm run build:types && npm run build:js",
         "build:types": "tsc --emitDeclarationOnly",
         "build:js": "babel src --out-dir lib --extensions \".tsx\" --ignore \"**/*.test.tsx\" --source-maps inline",
         "build:bundle": "webpack-cli --config ./webpack.config.js --mode production",
@@ -107,7 +106,7 @@
         "test": "jest --watchAll",
         "test:once": "jest",
         "coverage": "jest --coverage && cat ./coverage/lcov.info | coveralls",
-        "preinstall": "rimraf dist"
+        "preinstall": "rm -rf dist"
     },
     "license": "MIT"
 }


### PR DESCRIPTION
The `rimraf` package causes build issues on platforms such as Netlify. Proposal to replace with standard shell commands `rm -rf`. (Relates to issue #23 )