### PR TITLE
#46 Missing default props on sdk request, when option prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -202,8 +202,15 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
     }
 
     private addPaypalSdk() {
-        const { options, onButtonReady } = this.props;
+        const { onButtonReady } = this.props;
+        let { options } = this.props;
         const queryParams: string[] = [];
+
+        Object.keys(PayPalButton.defaultProps.options).map(i => {
+            if (!options.hasOwnProperty(i)) {
+                options = Object.assign(options, {[i]:PayPalButton.defaultProps.options[i]});
+            }
+        });
 
         // replacing camelCase with dashes
         Object.keys(options).forEach(k => {
@@ -225,7 +232,7 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
         script.onerror = () => {
             throw new Error("Paypal SDK could not be loaded.");
         };
-    
+
         document.body.appendChild(script);
     }
 }


### PR DESCRIPTION
fix for https://github.com/Luehang/react-paypal-button-v2/issues/46
You can pass both default props, of course, but it's not clear for newcomers to lib
Please, review and give some comments