### PR TITLE
fix window present precondition

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -174,7 +174,7 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
         const { isSdkReady } = this.state;
 
         if (
-            !isSdkReady &&
+            !isSdkReady ||
             (typeof window === "undefined" || window.paypal === undefined)
         ) {
             return null;


### PR DESCRIPTION
Probably we should return `null` if the PayPal OR window isn't present/ready.

Otherwise we could get a `Cannot read property '...' of undefined` Error in line 183.