### PR TITLE
Fix: call 'onError' with "Paypal SDK could not be loaded." error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -222,7 +222,7 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
     }
 
     private addPaypalSdk() {
-        const { options, onButtonReady } = this.props;
+        const { options, onButtonReady, onError } = this.props;
         const queryParams: string[] = [];
 
         // replacing camelCase with dashes
@@ -243,7 +243,12 @@ class PayPalButton extends React.Component<PayPalButtonProps, PayPalButtonState>
             }
         };
         script.onerror = () => {
-            throw new Error("Paypal SDK could not be loaded.");
+            const error = new Error("Paypal SDK could not be loaded.");
+            if (onError) {
+                onError(error);
+            } else {
+                throw error;
+            }
         };
     
         document.body.appendChild(script);


### PR DESCRIPTION
In my case, I was able to handle cases when PayPal SDK could not be loaded, but I couldn't prevent an exception being reported to Sentry.

I think it would appropriate to handle this error with the `onError` prop, as it's meant to catch all exceptions according to the docs:
> If an error prevents buyer checkout. This error handler is a catch-all. 

Should also help with this issue #40 